### PR TITLE
Fix createProject.sh on MacOS

### DIFF
--- a/addFreeRTOS.sh
+++ b/addFreeRTOS.sh
@@ -18,13 +18,13 @@ if [ $cont == "Y" ]; then
     freertosdefs='# FreeRTOS specific\nFREERTOSDIR=FreeRTOS/\nFREERTOSSRC=FreeRTOS/Source/\nFREERTOSSOURCES=$(wildcard $(FREERTOSSRC)*.c)\nFREERTOSMEGAPORT=$(FREERTOSSRC)portable/GCC/ATMega1284/\nFREERTOSMEGAPORTSOURCES=$(wildcard $(FREERTOSMEGAPORT)*.c)\nFREERTOSOBJS=$(patsubst $(FREERTOSSRC)%,$(PATHO)%,$(FREERTOSSOURCES:.c=.o)) \\\n\t$(patsubst $(FREERTOSMEGAPORT)%,$(PATHO)%,$(FREERTOSMEGAPORTSOURCES:.c=.o))\nFREERTOSINC=-I$(FREERTOSSRC)include/ -I$(FREERTOSMEGAPORT) -I$(FREERTOSDIR)\nOBJS+= $(FREERTOSOBJS)\n'
     freertosrules='$(PATHO)%.o: $(FREERTOSSRC)%.c\n\t@$(AVR) $(DEBUGFLAGS) $(SIMFLAGS) $(FLAGS) $(INCLUDES) -c -o $@ $<\n\n$(PATHO)%.o: $(FREERTOSMEGAPORT)%.c\n\t@$(AVR) $(DEBUGFLAGS) $(SIMFLAGS) $(FLAGS) $(INCLUDES) -c -o $@ $<\n'
 
-    sed "/^CLEAN.*/i $freertosdefs" Makefile > Makefile.new
+    awk -v "freertosdefs=$freertosdefs" '/^CLEAN.*/ && !x {print freertosdefs; x=1} 1' $name/Makefile > $name/Makefile.new
     mv Makefile.new Makefile
 
     sed '/^INCLUDES/ s/$/ $(FREERTOSINC)/' Makefile > Makefile.new
     mv Makefile.new Makefile
 
-    sed "/^clean.*/i $freertosrules" Makefile > Makefile.new
+    awk -v "freertosrules=$freertosrules" '/^clean.*/ && !x {print freertosrules; x=1} 1' $name/Makefile > $name/Makefile.new
     mv Makefile.new Makefile
 fi
 

--- a/createProject.sh
+++ b/createProject.sh
@@ -119,13 +119,13 @@ if [ "$includeFreeRTOS" == "Y" ]; then
     freertosdefs='# FreeRTOS specific\nFREERTOSDIR=FreeRTOS/\nFREERTOSSRC=FreeRTOS/Source/\nFREERTOSSOURCES=$(wildcard $(FREERTOSSRC)*.c)\nFREERTOSMEGAPORT=$(FREERTOSSRC)portable/GCC/ATMega1284/\nFREERTOSMEGAPORTSOURCES=$(wildcard $(FREERTOSMEGAPORT)*.c)\nFREERTOSOBJS=$(patsubst $(FREERTOSSRC)%,$(PATHO)%,$(FREERTOSSOURCES:.c=.o)) \\\n\t$(patsubst $(FREERTOSMEGAPORT)%,$(PATHO)%,$(FREERTOSMEGAPORTSOURCES:.c=.o))\nFREERTOSINC=-I$(FREERTOSSRC)include/ -I$(FREERTOSMEGAPORT) -I$(FREERTOSDIR)\nOBJS+= $(FREERTOSOBJS)\n'
     freertosrules='$(PATHO)%.o: $(FREERTOSSRC)%.c\n\t@$(AVR) $(DEBUGFLAGS) $(SIMFLAGS) $(FLAGS) $(INCLUDES) -c -o $@ $<\n\n$(PATHO)%.o: $(FREERTOSMEGAPORT)%.c\n\t@$(AVR) $(DEBUGFLAGS) $(SIMFLAGS) $(FLAGS) $(INCLUDES) -c -o $@ $<\n'
 
-    sed "/^CLEAN.*/i $freertosdefs" $name/Makefile > $name/Makefile.new
+    awk -v "freertosdefs=$freertosdefs" '/^CLEAN.*/ && !x {print freertosdefs; x=1} 1' $name/Makefile > $name/Makefile.new
     mv $name/Makefile.new $name/Makefile
 
     sed '/^INCLUDES/ s/$/ $(FREERTOSINC)/' $name/Makefile > $name/Makefile.new
     mv $name/Makefile.new $name/Makefile
 
-    sed "/^clean.*/i $freertosrules" $name/Makefile > $name/Makefile.new
+    awk -v "freertosrules=$freertosrules" '/^clean.*/ && !x {print freertosrules; x=1} 1' $name/Makefile > $name/Makefile.new
     mv $name/Makefile.new $name/Makefile
 fi
 


### PR DESCRIPTION
This fixes the `sed` command issue present on MacOS. `sed` isn't very portable between operating systems (BSD vs. GNU sed). Replacing those broken commands with equivalent `awk` command solved the bug on MacOS.

The fixes in this branch were tested on both MacOS 10.14 Mojave and Ubuntu 18.04 Bionic.