### PR TITLE
Fixes an issue on Linux

### DIFF
--- a/templates/MakefileTemplate
+++ b/templates/MakefileTemplate
@@ -80,13 +80,13 @@ program: $(PATHB)main.hex
 	$(PROGRAM) -c $(PROGRAMMER) -p $(MMCU) $(VERBOSITY) -U $(MEMORY):w:$< #|| $(ADDVERBOSITY)
 
 debug: $(PATHO)main.elf
-	@sed -i "s/break main.c:.*/break main.c:$(WHILELINENO)/" $(INITDEBUGGER)
+	@sed -i "s/break main.c:.*/break main.c:$(WHILELINENO)/" $(INITGDBDEBUGGER)
 	$(SIMAVR) -g -mmcu=$(MMCU) -f $(FREQ) $< &
 	-$(GDB) $(GDBDEBUGGING)
 	@pkill simavr
 
 test: $(PATHO)main.elf
-	@sed -i "s/break main.c:.*/break main.c:$(WHILELINENO)/" $(INITDEBUGGER)
+	@sed -i "s/break main.c:.*/break main.c:$(WHILELINENO)/" $(INITGDBDEBUGGER)
 	$(SIMAVR) -g -mmcu=$(MMCU) -f $(FREQ) $< &
 	-$(GDB) $(GDBTESTING)
 	@pkill simavr


### PR DESCRIPTION
This commit fixes an issue where when running `make debug` and `make test` on Linux, it returns an error saying 
```
sed: no input files
make: *** [Makefile:87: debug] Error 4
```